### PR TITLE
Fix package URL in commentary

### DIFF
--- a/gnome-screencast.el
+++ b/gnome-screencast.el
@@ -6,7 +6,7 @@
 ;; Author: Jürgen Hötzel <juergen@hoetzel.info>
 ;; Keywords: tools, multimedia
 ;; Package-Requires: ((emacs "25"))
-;; URL: https://github.com/juergenhoetzel/gnome-screencast.el
+;; URL: https://github.com/juergenhoetzel/emacs-gnome-screencast
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Replace "gnome-screencast.el" with "emacs-gnome-screencast" in the package URL.

* `gnome-screencast.el`: Fix package URL in commentary.